### PR TITLE
vendor: notch-city: Add 3 mode display cutout handler [2/3]

### DIFF
--- a/config/packages.mk
+++ b/config/packages.mk
@@ -22,6 +22,11 @@ PRODUCT_PACKAGES += \
     Recorder \
     WeatherClient
 
+# Cutout control overlays
+PRODUCT_PACKAGES += \
+    HideCutout \
+    StatusBarStock
+
 # Weather
 PRODUCT_COPY_FILES += \
     vendor/revengeos/prebuilt/etc/permissions/com.android.providers.weather.xml:system/etc/permissions/com.android.providers.weather.xml \

--- a/packages/overlays/Common/HideCutout/Android.mk
+++ b/packages/overlays/Common/HideCutout/Android.mk
@@ -1,0 +1,11 @@
+LOCAL_PATH:= $(call my-dir)
+include $(CLEAR_VARS)
+
+LOCAL_MODULE_TAGS := optional
+
+LOCAL_PACKAGE_NAME := HideCutout
+LOCAL_SDK_VERSION := current
+LOCAL_CERTIFICATE := platform
+LOCAL_PRIVILEGED_MODULE := false
+
+include $(BUILD_PACKAGE)

--- a/packages/overlays/Common/HideCutout/AndroidManifest.xml
+++ b/packages/overlays/Common/HideCutout/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.potato.overlay.hidecutout"
+    android:versionCode="1"
+    android:versionName="1.0">
+    <overlay android:targetPackage="android" android:priority="1" />
+
+    <application android:label="@string/label" android:hasCode="false"/>
+</manifest>

--- a/packages/overlays/Common/HideCutout/res/values/config.xml
+++ b/packages/overlays/Common/HideCutout/res/values/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <bool name="config_fillMainBuiltInDisplayCutout">false</bool>
+    <bool name="config_maskMainBuiltInDisplayCutout">true</bool>
+</resources>

--- a/packages/overlays/Common/HideCutout/res/values/strings.xml
+++ b/packages/overlays/Common/HideCutout/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="label">Cutout Hide</string>
+</resources>

--- a/packages/overlays/Common/StatusBarStock/Android.mk
+++ b/packages/overlays/Common/StatusBarStock/Android.mk
@@ -1,0 +1,11 @@
+LOCAL_PATH:= $(call my-dir)
+include $(CLEAR_VARS)
+
+LOCAL_MODULE_TAGS := optional
+
+LOCAL_PACKAGE_NAME := StatusBarStock
+LOCAL_SDK_VERSION := current
+LOCAL_CERTIFICATE := platform
+LOCAL_PRIVILEGED_MODULE := false
+
+include $(BUILD_PACKAGE)

--- a/packages/overlays/Common/StatusBarStock/AndroidManifest.xml
+++ b/packages/overlays/Common/StatusBarStock/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.potato.overlay.statusbarstock"
+    android:versionCode="1"
+    android:versionName="1.0">
+    <overlay android:targetPackage="android" android:priority="1" />
+
+    <application android:label="@string/label" android:hasCode="false"/>
+</manifest>

--- a/packages/overlays/Common/StatusBarStock/res/values/config.xml
+++ b/packages/overlays/Common/StatusBarStock/res/values/config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Height of the status bar -->
+    <dimen name="status_bar_height_portrait">28dp</dimen>
+    <dimen name="status_bar_height_landscape">28dp</dimen>
+</resources>

--- a/packages/overlays/Common/StatusBarStock/res/values/strings.xml
+++ b/packages/overlays/Common/StatusBarStock/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="label">Default StatusBar</string>
+</resources>


### PR DESCRIPTION
[@AgentFabulous - POSP]
- Introduces the HideCutout and StatusBarStock overlay used in the
  3 mode display cutout handler. The HideCutout overlay is necessary
  since we can't register a content observer in the display manager code.
  We only have access to resources during boot. Thus, leave this as an
  overlay and let the config and overlay change methods handle this.
  Though we can probably do statusbar stock height toggling in the
  SystemUI code without overlays, I kinda got lazy by the end, just
  live with it god damn it xD

Signed-off-by: Kshitij Gupta <kshitijgm@gmail.com>
Change-Id: I62f63f39bcb410cfbc68e0028b9cef3d748d7eb6