### PR TITLE
config: Add dataservices to PRODUCT_SOONG_NAMESPACES if needed

### DIFF
--- a/config/BoardConfigQcom.mk
+++ b/config/BoardConfigQcom.mk
@@ -107,6 +107,11 @@ ifneq ($(USE_DEVICE_SPECIFIC_DATA_IPA_CFG_MGR),true)
     PRODUCT_SOONG_NAMESPACES += vendor/qcom/opensource/data-ipa-cfg-mgr
 endif
 
+# Add dataservices to PRODUCT_SOONG_NAMESPACES if needed
+ifneq ($(USE_DEVICE_SPECIFIC_DATASERVICES),true)
+    PRODUCT_SOONG_NAMESPACES += vendor/qcom/opensource/dataservices
+endif
+
 ifeq ($(TARGET_USE_QTI_BT_STACK),true)
 PRODUCT_SOONG_NAMESPACES += \
     vendor/qcom/opensource/commonsys/packages/apps/Bluetooth \


### PR DESCRIPTION
The mk files in vendor/qcom/opensource/dataservices were
converted to bp, so this is needed to avoid duplicate module
build errors on devices that use a different dataservices lib.

Change-Id: Ic5c1ad77342c045253cfd093c76706862ed6fd0e